### PR TITLE
reverting the usage of GITHUB_TOKEN;

### DIFF
--- a/.github/workflows/send-sync-request.yml
+++ b/.github/workflows/send-sync-request.yml
@@ -17,7 +17,7 @@ jobs:
           curl -L \
             -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Authorization: Bearer ${{ secrets.EDITOR_REPOSITORY_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/opengql/editor/actions/workflows/synchronize-with-grammar-repo.yml/dispatches \
             -d '{"ref":"main"}'
@@ -27,7 +27,7 @@ jobs:
           curl -L \
             -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Authorization: Bearer ${{ secrets.EDITOR_REPOSITORY_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/opengql/railroad/actions/workflows/deploy-application.yml/dispatches \
             -d '{"ref":"main"}'


### PR DESCRIPTION
The problem with this workflow is that it communicates with other repositories with Rest API. The GITHUB_TOKEN has only permissions to the repository that the action is executed on.